### PR TITLE
Storing and loading the ProjectContext from local storage

### DIFF
--- a/consistent/package.json
+++ b/consistent/package.json
@@ -8,7 +8,7 @@
     "@emotion/styled": "^11.8.1",
     "@mui/icons-material": "^5.6.1",
     "@mui/material": "^5.6.1",
-    "@testing-library/jest-dom": "^5.16.1",
+    "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
     "file-saver": "^2.0.5",

--- a/consistent/src/components/context/ProjectContext.js
+++ b/consistent/src/components/context/ProjectContext.js
@@ -28,21 +28,60 @@ export const ProjectContextProvider=( {children} )=>{
         };
     };
 
-    const [ projectCells, setProjectCells ] = useState([emptyCell()]);
-    const [ projectData, setProjectData ] = useState(defaultProjectData());
-    const [ projectCorpus, setProjectCorpus ] = useState([]);
-    const [ isProjectLocked, setIsProjectLocked ] = useState(false);
+  const objectPropFromStorage = (propName, defaultValue) => {
+    //console.log("Loading prop from Storage:" + propName);
+    let anObject = JSON.parse(localStorage.getItem("obj"));
+    if (!anObject || !anObject[propName]) {
+      return typeof defaultValue === "function" ? defaultValue() : defaultValue;
+    }
+    return anObject[propName];
+  };
 
-    const [ projectTags, setProjectTags ] = useState([]);
-    const [ activeCellId, setActiveCellId ] = useState();
+  const [projectCells, setProjectCells] = useState(objectPropFromStorage("projectCells", () => [emptyCell()]));
+  const [projectData, setProjectData] = useState(objectPropFromStorage("projectData", () => defaultProjectData()));
+  const [projectCorpus, setProjectCorpus] = useState(objectPropFromStorage("projectCorpus", []));
+  const [isProjectLocked, setIsProjectLocked] = useState(objectPropFromStorage("isProjectLocked", false));
+
+  const [projectTags, setProjectTags] = useState(objectPropFromStorage("projectTags", []));
+  const [activeCellId, setActiveCellId] = useState(objectPropFromStorage("activeCellId"));
     // const [ projectFilename, setProjectFilename ] = useState(null);
 
-    const [ projectCellsHistory, setProjectCellsHistory ] = useState([projectCells]);
-    const [ historyIndex, setHistoryIndex ] = useState(0);
-    const [ isUndoDisabled, setIsUndoDisabled ] = useState(true);
-    const [ isRedoDisabled, setIsRedoDisabled ] = useState(true);
+  const [projectCellsHistory, setProjectCellsHistory] = useState(objectPropFromStorage("projectCellsHistory", () => [projectCells]));
+  const [historyIndex, setHistoryIndex] = useState(objectPropFromStorage("historyIndex", 0));
+  const [isUndoDisabled, setIsUndoDisabled] = useState(objectPropFromStorage("isUndoDisabled", true));
+  const [isRedoDisabled, setIsRedoDisabled] = useState(objectPropFromStorage("isRedoDisabled", true));
 
-    const [ isProjectLTR, setIsProjectLTR ] = useState(true);
+  const [isProjectLTR, setIsProjectLTR] = useState(objectPropFromStorage("isProjectLTR", true));
+
+  useEffect(() => {
+    let anObject = {
+      projectCells: projectCells,
+      projectData: projectData,
+      projectCorpus: projectCorpus,
+      isProjectLocked: isProjectLocked,
+      projectTags: projectTags,
+      activeCellId: activeCellId,
+      projectCellsHistory: projectCellsHistory,
+      historyIndex: historyIndex,
+      isUndoDisabled: isUndoDisabled,
+      isRedoDisabled: isRedoDisabled,
+      isProjectLTR: isProjectLTR,
+    };
+    console.log("Storing data");
+    localStorage.setItem("obj", JSON.stringify(anObject));
+  }, [
+    projectCells,
+    projectData,
+    projectCorpus,
+    isProjectLocked,
+    projectTags,
+    activeCellId,
+    projectCellsHistory,
+    historyIndex,
+    isUndoDisabled,
+    isRedoDisabled,
+    isProjectLTR,
+  ]);
 
     const updateProjectCells = (cells) => {
         setProjectCells(cells);

--- a/consistent/src/components/context/ProjectContext.js
+++ b/consistent/src/components/context/ProjectContext.js
@@ -28,32 +28,34 @@ export const ProjectContextProvider=( {children} )=>{
         };
     };
 
-  const objectPropFromStorage = (propName, defaultValue) => {
+  const STORAGE_KEY = "ProjectContext";
+  const stateFromStorage = (stateName, defaultValue) => {
     //console.log("Loading prop from Storage:" + propName);
-    let anObject = JSON.parse(localStorage.getItem("obj"));
-    if (!anObject || !anObject[propName]) {
+    let anObject = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    if (!anObject || !anObject[stateName]) {
       return typeof defaultValue === "function" ? defaultValue() : defaultValue;
     }
-    return anObject[propName];
+    return anObject[stateName];
   };
 
-  const [projectCells, setProjectCells] = useState(objectPropFromStorage("projectCells", () => [emptyCell()]));
-  const [projectData, setProjectData] = useState(objectPropFromStorage("projectData", () => defaultProjectData()));
-  const [projectCorpus, setProjectCorpus] = useState(objectPropFromStorage("projectCorpus", []));
-  const [isProjectLocked, setIsProjectLocked] = useState(objectPropFromStorage("isProjectLocked", false));
+  const [projectCells, setProjectCells] = useState(stateFromStorage("projectCells", () => [emptyCell()]));
+  const [projectData, setProjectData] = useState(stateFromStorage("projectData", () => defaultProjectData()));
+  const [projectCorpus, setProjectCorpus] = useState(stateFromStorage("projectCorpus", []));
+  const [isProjectLocked, setIsProjectLocked] = useState(stateFromStorage("isProjectLocked", false));
 
-  const [projectTags, setProjectTags] = useState(objectPropFromStorage("projectTags", []));
-  const [activeCellId, setActiveCellId] = useState(objectPropFromStorage("activeCellId"));
+  const [projectTags, setProjectTags] = useState(stateFromStorage("projectTags", []));
+  const [activeCellId, setActiveCellId] = useState(stateFromStorage("activeCellId"));
     // const [ projectFilename, setProjectFilename ] = useState(null);
 
-  const [projectCellsHistory, setProjectCellsHistory] = useState(objectPropFromStorage("projectCellsHistory", () => [projectCells]));
-  const [historyIndex, setHistoryIndex] = useState(objectPropFromStorage("historyIndex", 0));
-  const [isUndoDisabled, setIsUndoDisabled] = useState(objectPropFromStorage("isUndoDisabled", true));
-  const [isRedoDisabled, setIsRedoDisabled] = useState(objectPropFromStorage("isRedoDisabled", true));
+  const [projectCellsHistory, setProjectCellsHistory] = useState(stateFromStorage("projectCellsHistory", () => [projectCells]));
+  const [historyIndex, setHistoryIndex] = useState(stateFromStorage("historyIndex", 0));
+  const [isUndoDisabled, setIsUndoDisabled] = useState(stateFromStorage("isUndoDisabled", true));
+  const [isRedoDisabled, setIsRedoDisabled] = useState(stateFromStorage("isRedoDisabled", true));
 
-  const [isProjectLTR, setIsProjectLTR] = useState(objectPropFromStorage("isProjectLTR", true));
+  const [isProjectLTR, setIsProjectLTR] = useState(stateFromStorage("isProjectLTR", true));
 
   useEffect(() => {
+    //a hook to store all states as soon as any changes
     let anObject = {
       projectCells: projectCells,
       projectData: projectData,
@@ -68,7 +70,7 @@ export const ProjectContextProvider=( {children} )=>{
       isProjectLTR: isProjectLTR,
     };
     console.log("Storing data");
-    localStorage.setItem("obj", JSON.stringify(anObject));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(anObject));
   }, [
     projectCells,
     projectData,


### PR DESCRIPTION
To allow persistency across refreshes, all states of the ProjectContext are persisted upon changes and loaded from storage upon initialization.
The storing mechanism could be more granular. Currently, all states are written to the storage if a single state changes.
Closes #26 