### PR TITLE
Fixing the bug of consequent loading of the same file

### DIFF
--- a/consistent/src/components/layout/NavigationBar.js
+++ b/consistent/src/components/layout/NavigationBar.js
@@ -63,6 +63,9 @@ function NavigationBar() {
         setSelectedFile(e.target.files[0]);
         setIsFilePicked(true);
         fileReader.readAsText(e.target.files[0]);
+        //Resetting the hidden input value, so consequent
+        //loading of the same file would trigger the onChange event
+        e.target.value = null;
     }
 
     fileReader.onload=(e) => {


### PR DESCRIPTION
A reset of the file input field value has to happen, otherwise, the onChange wouldn't be triggered when choosing the same file again. 